### PR TITLE
Update install_repo.yml with latest elrepo version

### DIFF
--- a/tasks/install_repo.yml
+++ b/tasks/install_repo.yml
@@ -9,13 +9,13 @@
 - name: Set elrepo_ver fact (el7)
   tags: elrepo-release
   set_fact:
-    elrepo_ver: "7.0-2.el7"
+    elrepo_ver: "7.0-3.el7"
   when: elrepo_rel == '7'
 
 - name: Set elrepo_ver fact (el6)
   tags: elrepo-release
   set_fact:
-    elrepo_ver: "6-6.el6"
+    elrepo_ver: "6-8.el6"
   when: elrepo_rel == '6'
 
 - name: Set elrepo_ver fact (el5)


### PR DESCRIPTION
Using this on CentOS 7 failed because the version has increased and the old RPM is no longer there (just a text file containing the new RPM, which was confusing).

This adds the latest version numbers for RHEL 6 and 7 (not sure 5 is supported anymore).