### PR TITLE
Fix a yum crash issue

### DIFF
--- a/tasks/elrepo_kernel.yml
+++ b/tasks/elrepo_kernel.yml
@@ -2,10 +2,10 @@
 - name: Attempting to purge old kernel packages
   become: true
   yum:
-    disable_plugin: "{{ elrepo_disable_plugin|join(',') }}"
-    disablerepo: "{{ elrepo_disablerepo|join(',') }}"
-    enable_plugin: "{{ elrepo_enable_plugin|join(',') }}"
-    enablerepo: "{{ elrepo_enablerepo|join(',') }}"
+    disable_plugin: "{{ elrepo_disable_plugin|join(',')|default([],true) }}"
+    disablerepo: "{{ elrepo_disablerepo|join(',')|default([],true) }}"
+    enable_plugin: "{{ elrepo_enable_plugin|join(',')|default([],true) }}"
+    enablerepo: "{{ elrepo_enablerepo|join(',')|default([],true) }}"
     name: "{{ item }}"
     state: absent
   loop:
@@ -24,10 +24,10 @@
 - name: Ensure that the elrepo kernel packages are installed
   become: true
   yum:
-    disable_plugin: "{{ elrepo_disable_plugin|join(',') }}"
-    disablerepo: "{{ elrepo_disablerepo|join(',') }}"
-    enable_plugin: "{{ elrepo_enable_plugin|join(',') }}"
-    enablerepo: "{{ elrepo_enablerepo|join(',') }}"
+    disable_plugin: "{{ elrepo_disable_plugin|join(',')|default([],true) }}"
+    disablerepo: "{{ elrepo_disablerepo|join(',')|default([],true) }}"
+    enable_plugin: "{{ elrepo_enable_plugin|join(',')|default([],true) }}"
+    enablerepo: "{{ elrepo_enablerepo|join(',')|default([],true) }}"
     name: "{{ item }}"
     state: present
   register: elrepo_kernel_installed
@@ -41,10 +41,10 @@
 - name: Ensure that the kernel tools packages are installed
   become: true
   yum:
-    disable_plugin: "{{ elrepo_disable_plugin|join(',') }}"
-    disablerepo: "{{ elrepo_disablerepo|join(',') }}"
-    enable_plugin: "{{ elrepo_enable_plugin|join(',') }}"
-    enablerepo: "{{ elrepo_enablerepo|join(',') }}"
+    disable_plugin: "{{ elrepo_disable_plugin|join(',')|default([],true) }}"
+    disablerepo: "{{ elrepo_disablerepo|join(',')|default([],true) }}"
+    enable_plugin: "{{ elrepo_enable_plugin|join(',')|default([],true) }}"
+    enablerepo: "{{ elrepo_enablerepo|join(',')|default([],true) }}"
     name: "{{ item }}"
     state: present
   loop:
@@ -77,10 +77,10 @@
 - name: Ensure that the required elrepo packages are installed
   become: true
   yum:
-    disable_plugin: "{{ elrepo_disable_plugin|join(',') }}"
-    disablerepo: "{{ elrepo_disablerepo|join(',') }}"
-    enable_plugin: "{{ elrepo_enable_plugin|join(',') }}"
-    enablerepo: "{{ elrepo_enablerepo|join(',') }}"
+    disable_plugin: "{{ elrepo_disable_plugin|join(',')|default([],true) }}"
+    disablerepo: "{{ elrepo_disablerepo|join(',')|default([],true) }}"
+    enable_plugin: "{{ elrepo_enable_plugin|join(',')|default([],true) }}"
+    enablerepo: "{{ elrepo_enablerepo|join(',')|default([],true) }}"
     name: "{{ item }}"
     state: present
   loop: "{{ elrepo_packages }}"

--- a/tasks/elrepo_repository.yml
+++ b/tasks/elrepo_repository.yml
@@ -27,10 +27,10 @@
 - name: Ensure that the elrepo-release package is installed
   become: true
   yum:
-    disable_plugin: "{{ elrepo_disable_plugin|join(',') }}"
-    disablerepo: "{{ elrepo_disablerepo|join(',') }}"
-    enable_plugin: "{{ elrepo_enable_plugin|join(',') }}"
-    enablerepo: "{{ elrepo_enablerepo|join(',') }}"
+    disable_plugin: "{{ elrepo_disable_plugin|join(',')|default([],true) }}"
+    disablerepo: "{{ elrepo_disablerepo|join(',')|default([],true) }}"
+    enable_plugin: "{{ elrepo_enable_plugin|join(',')|default([],true) }}"
+    enablerepo: "{{ elrepo_enablerepo|join(',')|default([],true) }}"
     name: "{{ elrepo_tempfile.path }}"
     state: present
   register: elrepo_yum
@@ -64,10 +64,10 @@
 - name: Ensure that the required elrepo packages are installed
   become: true
   yum:
-    disable_plugin: "{{ elrepo_disable_plugin|join(',') }}"
-    disablerepo: "{{ elrepo_disablerepo|join(',') }}"
-    enable_plugin: "{{ elrepo_enable_plugin|join(',') }}"
-    enablerepo: "{{ elrepo_enablerepo|join(',') }}"
+    disable_plugin: "{{ elrepo_disable_plugin|join(',')|default([],true) }}"
+    disablerepo: "{{ elrepo_disablerepo|join(',')|default([],true) }}"
+    enable_plugin: "{{ elrepo_enable_plugin|join(',')|default([],true) }}"
+    enablerepo: "{{ elrepo_enablerepo|join(',')|default([],true) }}"
     name: "{{ item }}"
     state: present
   loop: "{{ elrepo_packages }}"


### PR DESCRIPTION
Ansible code:

```
  roles:
  - role: linuxhq.epel
  - role: linuxhq.elrepo
    elrepo_enablerepo:
    - epel
    elrepo_kernel: true
    elrepo_kernel_version: ml
    elrepo_repository_kernel: true
```

Test platform: CentOS 7 x64 on Vultr.com

Issue:

```
TASK [linuxhq.elrepo : Ensure that the elrepo-release package is installed] *************************************************************************************************************
task path: /home/******/.ansible/roles/linuxhq.elrepo/tasks/elrepo_repository.yml:27
<*.*.*.*> ESTABLISH SSH CONNECTION FOR USER: root
<*.*.*.*> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o 'IdentityFile="vultr_key.pem"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/home/******/.ansible/cp/d18e0e300b *.*.*.* '/bin/sh -c '"'"'echo ~root && sleep 0'"'"''
<*.*.*.*> (0, '/root\n', '')
<*.*.*.*> ESTABLISH SSH CONNECTION FOR USER: root
<*.*.*.*> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o 'IdentityFile="vultr_key.pem"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/home/******/.ansible/cp/d18e0e300b *.*.*.* '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1550648422.5-152831345775215 `" && echo ansible-tmp-1550648422.5-152831345775215="` echo /root/.ansible/tmp/ansible-tmp-1550648422.5-152831345775215 `" ) && sleep 0'"'"''
<*.*.*.*> (0, 'ansible-tmp-1550648422.5-152831345775215=/root/.ansible/tmp/ansible-tmp-1550648422.5-152831345775215\n', '')
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/packaging/os/yum.py
<*.*.*.*> PUT /home/******/.ansible/tmp/ansible-local-292343ixLuj/tmp5CWd6v TO /root/.ansible/tmp/ansible-tmp-1550648422.5-152831345775215/AnsiballZ_yum.py
<*.*.*.*> SSH: EXEC sftp -b - -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o 'IdentityFile="vultr_key.pem"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/home/******/.ansible/cp/d18e0e300b '[*.*.*.*]'
<*.*.*.*> (0, 'sftp> put /home/******/.ansible/tmp/ansible-local-292343ixLuj/tmp5CWd6v /root/.ansible/tmp/ansible-tmp-1550648422.5-152831345775215/AnsiballZ_yum.py\n', '')
<*.*.*.*> ESTABLISH SSH CONNECTION FOR USER: root
<*.*.*.*> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o 'IdentityFile="vultr_key.pem"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/home/******/.ansible/cp/d18e0e300b *.*.*.* '/bin/sh -c '"'"'chmod u+x /root/.ansible/tmp/ansible-tmp-1550648422.5-152831345775215/ /root/.ansible/tmp/ansible-tmp-1550648422.5-152831345775215/AnsiballZ_yum.py && sleep 0'"'"''
<*.*.*.*> (0, '', '')
<*.*.*.*> ESTABLISH SSH CONNECTION FOR USER: root
<*.*.*.*> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o 'IdentityFile="vultr_key.pem"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/home/******/.ansible/cp/d18e0e300b -tt *.*.*.* '/bin/sh -c '"'"'/usr/bin/python /root/.ansible/tmp/ansible-tmp-1550648422.5-152831345775215/AnsiballZ_yum.py && sleep 0'"'"''
<*.*.*.*> (1, '\r\n{"changed": false, "results": [""], "failed": true, "rc": 1, "invocation": {"module_args": {"update_cache": false, "disable_excludes": null, "exclude": [], "allow_downgrade": false, "disable_gpg_check": false, "conf_file": null, "use_backend": "auto", "state": "present", "disablerepo": [""], "releasever": null, "skip_broken": false, "autoremove": false, "enable_plugin": [""], "installroot": "/", "name": ["/tmp/elrepo.WQIH30.rpm"], "download_only": false, "bugfix": false, "list": null, "install_repoquery": true, "update_only": false, "disable_plugin": [""], "enablerepo": ["epel"], "security": false, "validate_certs": true}}, "msg": "Traceback (most recent call last):\\n  File \\"/usr/bin/yum\\", line 29, in <module>\\n    yummain.user_main(sys.argv[1:], exit_code=True)\\n  File \\"/usr/share/yum-cli/yummain.py\\", line 375, in user_main\\n    errcode = main(args)\\n  File \\"/usr/share/yum-cli/yummain.py\\", line 170, in main\\n    base.getOptionsConfig(args)\\n  File \\"/usr/share/yum-cli/cli.py\\", line 226, in getOptionsConfig\\n    opts = self.optparser.firstParse(args)\\n  File \\"/usr/share/yum-cli/cli.py\\", line 2299, in firstParse\\n    args)\\n  File \\"/usr/share/yum-cli/cli.py\\", line 2639, in _filtercmdline\\n    if next[0] == \'-\':\\nIndexError: string index out of range\\n"}\r\n', 'Shared connection to *.*.*.* closed.\r\n')
<*.*.*.*> Failed to connect to the host via ssh: Shared connection to *.*.*.* closed.
<*.*.*.*> ESTABLISH SSH CONNECTION FOR USER: root
<*.*.*.*> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o 'IdentityFile="vultr_key.pem"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/home/******/.ansible/cp/d18e0e300b *.*.*.* '/bin/sh -c '"'"'rm -f -r /root/.ansible/tmp/ansible-tmp-1550648422.5-152831345775215/ > /dev/null 2>&1 && sleep 0'"'"''
<*.*.*.*> (0, '', '')
fatal: [CheeseLabs Server]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "allow_downgrade": false, 
            "autoremove": false, 
            "bugfix": false, 
            "conf_file": null, 
            "disable_excludes": null, 
            "disable_gpg_check": false, 
            "disable_plugin": [
                ""
            ], 
            "disablerepo": [
                ""
            ], 
            "download_only": false, 
            "enable_plugin": [
                ""
            ], 
            "enablerepo": [
                "epel"
            ], 
            "exclude": [], 
            "install_repoquery": true, 
            "installroot": "/", 
            "list": null, 
            "name": [
                "/tmp/elrepo.WQIH30.rpm"
            ], 
            "releasever": null, 
            "security": false, 
            "skip_broken": false, 
            "state": "present", 
            "update_cache": false, 
            "update_only": false, 
            "use_backend": "auto", 
            "validate_certs": true
        }
    }, 
    "msg": "Traceback (most recent call last):\n  File \"/usr/bin/yum\", line 29, in <module>\n    yummain.user_main(sys.argv[1:], exit_code=True)\n  File \"/usr/share/yum-cli/yummain.py\", line 375, in user_main\n    errcode = main(args)\n  File \"/usr/share/yum-cli/yummain.py\", line 170, in main\n    base.getOptionsConfig(args)\n  File \"/usr/share/yum-cli/cli.py\", line 226, in getOptionsConfig\n    opts = self.optparser.firstParse(args)\n  File \"/usr/share/yum-cli/cli.py\", line 2299, in firstParse\n    args)\n  File \"/usr/share/yum-cli/cli.py\", line 2639, in _filtercmdline\n    if next[0] == '-':\nIndexError: string index out of range\n", 
    "rc": 1, 
    "results": [
        ""
    ]
}
```
I believe the issue is cause by following fields:

```
            "disable_plugin": [
                ""
            ], 
            "disablerepo": [
                ""
            ], 
            "enable_plugin": [
                ""
            ], 
```
These should be:

```
            "disable_plugin": [], 
            "disablerepo": [], 
            "enable_plugin": [], 
```

This MR resolves the issue.