### PR TITLE
Add 'elrepo_version' variable to 'defaults' variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 elrepo_dist: "{{ ansible_distribution_major_version }}"
-elrepo_version: "{{ '7.0-4.el7' if elrepo_dist == '7' else '6-9.el6' }}"
+elrepo_version:
+  '6': 6-9.el6
+  '7': 7.0-4.el7
+  '8': 8.0-2.el8
+
 elrepo_disable_plugin: []
 elrepo_disablerepo: []
 elrepo_enable_plugin: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 elrepo_dist: "{{ ansible_distribution_major_version }}"
+elrepo_version: "{{ '7.0-4.el7' if elrepo_dist == '7' else '6-9.el6' }}"
 elrepo_disable_plugin: []
 elrepo_disablerepo: []
 elrepo_enable_plugin: []

--- a/tasks/elrepo_repository.yml
+++ b/tasks/elrepo_repository.yml
@@ -1,14 +1,4 @@
 ---
-- name: Attempting to set el6 elrepo_dist fact
-  set_fact:
-    elrepo_version: "6-9.el6"
-  when: elrepo_dist == '6'
-
-- name: Attempting to set el7 elrepo_dist fact
-  set_fact:
-    elrepo_version: "7.0-4.el7"
-  when: elrepo_dist == '7'
-
 - name: Attempting to generate temporary file
   tempfile:
     prefix: 'elrepo.'

--- a/tasks/elrepo_repository.yml
+++ b/tasks/elrepo_repository.yml
@@ -10,7 +10,7 @@
   get_url:
     dest: "{{ elrepo_tempfile.path }}"
     force: yes
-    url: "https://www.elrepo.org/elrepo-release-{{ elrepo_version }}.elrepo.noarch.rpm"
+    url: "https://www.elrepo.org/elrepo-release-{{ elrepo_version[elrepo_dist] }}.elrepo.noarch.rpm"
   register: elrepo_get_url
   when: elrepo_tempfile is success
 


### PR DESCRIPTION
We can use `elrepo_version` instead of updating each time a new version is released in the Elrepo package.